### PR TITLE
Missing rvm_scripts_path fixed

### DIFF
--- a/bin/install-rvm-completion
+++ b/bin/install-rvm-completion
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-rvm_scripts_path = ENV['rvm_scripts_path']
+rvm_scripts_path = "#{ENV['rvm_path']}/scripts"
 
 if rvm_scripts_path.nil? or not (File.exist?(rvm_scripts_path) and File.directory?(rvm_scripts_path))
   puts "Failed to find rvm scripts path - is rvm installed correctly?"
@@ -12,10 +12,10 @@ completion_target = File.join(rvm_scripts_path, 'rvm-completion.rb')
 
 if system "cp #{completion_source} #{completion_target}"
   puts "Success! rvm completion v#{File.read(File.expand_path(File.join(File.dirname(__FILE__), '../VERSION'))).chomp} installed to #{completion_target}", ""
-  
+
   puts "If you didn't do so before, please add the following line at the end of your"
   puts "~/.profile or ~/.bashrc and reload your terminal session"
-  puts "  complete -C $rvm_scripts_path/#{File.basename(completion_target)} -o default rvm"
+  puts "  complete -C $rvm_path/scripts/#{File.basename(completion_target)} -o default rvm"
 else
   puts "Failed to copy the completion script to #{rvm_scripts_path}!"
   exit 1

--- a/lib/rvm-completion.rb
+++ b/lib/rvm-completion.rb
@@ -14,25 +14,25 @@
 # (see http://github.com/ryanb/dotfiles/blob/master/bash/completion_scripts/project_completion)
 #
 class RVMCompletion
-  
+
   def initialize(comp_line)
     @comp_line = comp_line
   end
-  
+
   # Find a match for the current command line input
   def matches
     # Completion for root level rvm commands
     if rvm_command_incomplete?(shell_argument)
       return select(rvm_commands, shell_argument)
     end
-    
-    case shell_argument 
+
+    case shell_argument
       when /^use|uninstall|remove/
         return [] if shell_argument(3).length > 0
         select(rubies, shell_argument(2), :regexp => true)
       when /^install/
         select(rvm_ruby_aliases, shell_argument(2))
-      
+
       when /^gemset/
         case shell_argument(2)
           when /use|copy|clear|delete|export/
@@ -43,19 +43,19 @@ class RVMCompletion
       else
         []
     end
-    
+
   end
-  
+
   # Retrieves the shell argument at the specified position, defaults to first argument
   def shell_argument(level=1)
     @comp_line.split(' ')[level] || ''
   end
-  
+
   # Checks whether the first rvm command is complete
   def rvm_command_incomplete?(cmd)
     not rvm_commands.include?(cmd.strip)
   end
-  
+
   # Matches the given (partial?) command against the given collection
   def select(collection, command, options={})
     options = {:regexp => false}.merge(options)
@@ -64,40 +64,53 @@ class RVMCompletion
       item[0, command.length] == command or (options[:regexp] and item =~ /#{command}/)
     end.sort
   end
-  
+
   # Retrieves the current ruby binary path
   def current_ruby_path
     @current_ruby_path ||= `which ruby`
   end
-  
+
   # Retrieves the current rvm ruby
   def current_ruby
-    @current_ruby ||= current_ruby_path.strip.chomp.gsub(File.join(ENV['rvm_rubies_path'], '/'), '').split('/').first
+    @current_ruby ||= current_ruby_path.strip.chomp.gsub(File.join(rvm_rubies_path, '/'), '').split('/').first
   end
-  
+
   # Retrieves all available rubies
   def rubies
-    @rubies ||= Dir[File.join(ENV['rvm_rubies_path'], '*')].map {|r| File.basename(r) } + %w(system)
+    @rubies ||= Dir[File.join(rvm_rubies_path, '*')].map {|r| File.basename(r) } + %w(system)
   end
-  
+
   # Retrieves all available gemsets for the current ruby active in rvm
   def gemsets
-    @gemsets ||= Dir[File.join(ENV['rvm_gems_path'], "#{current_ruby}#{ENV['rvm_gemset_separator']}*")].map do |r|
-      File.basename(r).split(ENV['rvm_gemset_separator']).last
+    @gemsets ||= Dir[File.join(rvm_gems_path, "#{current_ruby}#{rvm_gemset_separator}*")].map do |r|
+      File.basename(r).split(rvm_gemset_separator).last
     end
   end
-  
+
   def rvm_commands
     %w(usage version use reload implode update reset info debug install uninstall remove wrapper ruby gem rake tests specs monitor gemset gemdir srcdir list fetch package notes)
   end
-  
+
   def gemset_commands
     %w(import export create copy empty delete name dir list gemdir install pristine clear use)
   end
-  
+
   def rvm_ruby_aliases
     %w(ruby jruby rbx ree macruby maglev ironruby mput)
   end
+
+  def rvm_rubies_path
+    File.join(ENV['rvm_path'], 'rubies')
+  end
+
+  def rvm_gems_path
+    File.join(ENV['rvm_path'], "gems")
+  end
+
+  def rvm_gemset_separator
+    ENV['rvm_gemset_separator'] || "@"
+  end
+
 end
 
 # A simple logger for debugging the completion


### PR DESCRIPTION
The ENV variable is missing, fixed in the patch
