### PR TITLE
Update rdoc rake task to work with more recent versions of rdoc (2.4.2+)...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,8 +46,8 @@ task :test => :check_dependencies
 
 task :default => :test
 
-require 'rake/rdoctask'
-Rake::RDocTask.new do |rdoc|
+require 'rdoc/task'
+RDoc::Task.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 
   rdoc.rdoc_dir = 'rdoc'


### PR DESCRIPTION
... and rake.

The rdoc rake task was moved from Rake::RDocTask to RDoc::Task.
